### PR TITLE
Fix typo in the link

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,5 +10,5 @@ This directory contains the source code for the front-end parts of Taipy GUI and
 
 Note that before the `taipy` part is built, the `taipy-gui` part must have been built.
 
-Please check the [Taipy GUI Front-end](taipy-gui/README.md) and [Taipy Front-end](taipyREADME.md)
+Please check the [Taipy GUI Front-end](taipy-gui/README.md) and [Taipy Front-end](taipy/README.md)
 README files for details.


### PR DESCRIPTION
## Description 

The link was not working since a slash was missing.